### PR TITLE
Show actual status code or failure reason in logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,17 +3,22 @@
 const { servers } = require("./asset");
 const { generateFiglet, get, generateHtml } = require("./utils");
 
+const didRequestSucceed = (reason) =>
+  typeof reason === "number" && reason >= 200 && reason < 300;
+
 async function checkAllServers() {
   const requests = servers.map(async (server, index) => {
     try {
-      const response = await get(server);
+      const { status } = await get(server);
 
-      console.log(`\x1b[32m✅ : ${server} 200\x1b[0m`);
-      return { index, status: response.status, server };
+      console.log(`\x1b[32m✅ : ${server} ${status}\x1b[0m`);
+      return { index, success: true, server };
     } catch (error) {
-      console.log(`\x1b[31m❌ : ${server} 500\x1b[0m`);
+      const reason = error.response?.status || error.code;
 
-      return { index, status: 500, server };
+      console.log(`\x1b[31m❌ : ${server} ${reason}\x1b[0m`);
+
+      return { index, success: didRequestSucceed(reason), server };
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "M. H. Nahib",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.7.2",
     "figlet": "^1.7.0"
   }
 }

--- a/utils/htmlGenerator.utils.js
+++ b/utils/htmlGenerator.utils.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const { exec } = require("child_process");
 
 module.exports = generateHtml = (results) => {
-  const sortedResults = results?.sort((a, b) => a.status - b.status);
+  const sortedResults = results?.sort((a, b) => b.success - a.success);
   const htmlContent = [];
   htmlContent.push(
     "<html><head><title>Server Check Results</title></head><body>"
@@ -12,10 +12,10 @@ module.exports = generateHtml = (results) => {
     "<h3>Developed by <a href='https://www.linkedin.com/in/mhnahib/'>M. H. Nahib</a></h3>"
   );
   for (const result of sortedResults) {
-    const { index, status, server } = result;
+    const { index, success, server } = result;
     htmlContent.push(
       `<p>${
-        status === 200 ? "✅" : "❌"
+        success ? "✅" : "❌"
       } : <a href=' ${server}' target="_blank"> ${server} </a></p>`
     );
   }


### PR DESCRIPTION
> [!NOTE]
> Sorry for not testing my work in the last pr. This time I tested my changes before opening a pr.

> [!TIP]
> All **2xx** series codes are considered as success in HTTP standard, not just **200**. Many public api's often use other **2xx** codes also for success. Although, Its quite rare to see it as a response while fetching the homepage of a server.

> [!TIP]
> Also consider setting a timeout option in axios for faster report generation. My suggestion would be **30 seconds** or **60** at best. But not more that that.

![image](https://github.com/MHNahib/bd-ftp-checker/assets/46617994/3ac619ba-bd1d-4735-bde4-7062efb42cb4)
